### PR TITLE
Add commit message to PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -19,3 +19,8 @@
 
 - [ ] Tests
 - [ ] Documented changes and additions
+
+
+## Commit message
+
+Commit message in angular format

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -23,4 +23,4 @@
 
 ## Commit message
 
-Commit message in angular format
+Commit message in [Angular Format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit)


### PR DESCRIPTION
## Related Issue(s)


## Proposed changes
Add commit message field to the PR template

## Additional info

Now that most repos use the Angular commit message format it is nice to have the proposed commit message in the PR. This allows us to check that added features and fixes are added in the message and that breaking changes are mentioned.

## How has this been tested?

## Checklist

- [ x] Tests
- [ x] Documented changes and additions


## Commit message
feat: add commit message to PR template

Now that most repos use the Angular commit message format it is nice to have the proposed commit message in the PR. This allows us to check that added features and fixes are added in the message and that breaking changes are mentioned.